### PR TITLE
fix: 헤더가 스킬 배너에 가려지는 이슈

### DIFF
--- a/src/app/relationreport/create/[fixedMenuSeq]/components/CreateRelationReportHeader.tsx
+++ b/src/app/relationreport/create/[fixedMenuSeq]/components/CreateRelationReportHeader.tsx
@@ -12,7 +12,7 @@ const CreateRelationReportHeader = () => {
   };
 
   return (
-    <header className="fixed max-w-xl w-full flex justify-center items-center h-[44px] bg-white">
+    <header className="fixed max-w-xl w-full flex justify-center items-center h-[44px] bg-white z-10">
       <Image
         className="cursor-pointer absolute left-4 top-1/2 -translate-y-1/2"
         src="/images/buttons-btn-back.svg"


### PR DESCRIPTION
<img width="375" alt="스크린샷 2023-12-06 오후 7 09 50" src="https://github.com/thingsflow/hellobot-report-webview/assets/116791055/19f924d3-9c9c-46f8-ba5e-74d3fa49c9e0">

새로운 모임 생성하기 페이지에서 헤더가 스킬 배너에 가려지는 이슈가 있어 수정하였습니다.