### PR TITLE
fix: 바텀시트가 완전히 열리면 스킬 클릭 활성화

### DIFF
--- a/src/app/relationreport/[reportSeq]/components/RelationReportBottomContainer.tsx
+++ b/src/app/relationreport/[reportSeq]/components/RelationReportBottomContainer.tsx
@@ -68,7 +68,7 @@ const RelationReportBottomContainer = () => {
       }
     }
 
-    if (isBottomSheetOpening) {
+    if (isBottomSheetOpened) {
       webview.goSkillDetailPage({ skillSeq: data?.skill?.seq });
       return;
     }


### PR DESCRIPTION
isBottomSheetOpening: 바텀시트 열기/닫기 이벤트가 시작될 때 값 업데이트됨
isBottomSheetOpened: 바텀시트가 완전히 열리거나, 완전히 닫혔을 때 값 없데이트됨.


바텀시트가 완전히 열리기 전에는 스킬 터치 이벤트가 활성화되지 않도록 수정하였습니다!